### PR TITLE
[MS-1003] Handling the case when SID is not installed, instead of crashing

### DIFF
--- a/app/src/main/java/com/simprints/intentlauncher/domain/IntentResult.kt
+++ b/app/src/main/java/com/simprints/intentlauncher/domain/IntentResult.kt
@@ -14,6 +14,8 @@ data class IntentResult(
     fun mappedResultCode(): String = when (code) {
         null -> "No result code"
         INVALID_CUSTOM_INTENT -> "INVALID CUSTOM INTENT"
+        ACTION_APP_NOT_FOUND -> "APP NOT FOUND FOR THIS ACTION"
+        SID_NOT_INSTALLED -> "SIMPRINTS ID APP NOT INSTALLED"
         Activity.RESULT_OK -> "OK"
         else -> getConstantNameByValue(code)
     }
@@ -35,5 +37,7 @@ data class IntentResult(
 
     companion object {
         const val INVALID_CUSTOM_INTENT = 9999
+        const val ACTION_APP_NOT_FOUND = 9998
+        const val SID_NOT_INSTALLED = 9997
     }
 }

--- a/app/src/main/java/com/simprints/intentlauncher/ui/custom/CustomIntentScreen.kt
+++ b/app/src/main/java/com/simprints/intentlauncher/ui/custom/CustomIntentScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.simprints.intentlauncher.domain.IntentResult.Companion.INVALID_CUSTOM_INTENT
+import com.simprints.intentlauncher.domain.IntentResult.Companion.ACTION_APP_NOT_FOUND
 import com.simprints.intentlauncher.tools.GenericIntentContract
 import com.simprints.intentlauncher.tools.collectAsStateLifecycleAware
 import com.simprints.intentlauncher.ui.composables.AccordionLayout
@@ -47,7 +47,7 @@ fun CustomIntentScreen(navController: NavHostController) {
         try {
             intentLauncher.launch(it)
         } catch (e: ActivityNotFoundException) {
-            vm.intentResultReceived(INVALID_CUSTOM_INTENT to null)
+            vm.intentResultReceived(ACTION_APP_NOT_FOUND to null)
         }
     }
 

--- a/app/src/main/java/com/simprints/intentlauncher/ui/custom/CustomIntentViewModel.kt
+++ b/app/src/main/java/com/simprints/intentlauncher/ui/custom/CustomIntentViewModel.kt
@@ -56,7 +56,9 @@ class CustomIntentViewModel @Inject constructor(
         cacheFields(it)
 
         val intent = Intent(it.action).apply {
-            it.extras.lines().forEach {
+            it.extras.lines().filter {
+                "=" in it
+            }.forEach {
                 val (key, value) = it.split("=")
                 putExtra(key, value)
             }

--- a/app/src/main/java/com/simprints/intentlauncher/ui/intent/IntentScreen.kt
+++ b/app/src/main/java/com/simprints/intentlauncher/ui/intent/IntentScreen.kt
@@ -1,5 +1,6 @@
 package com.simprints.intentlauncher.ui.intent
 
+import android.content.ActivityNotFoundException
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -53,7 +54,13 @@ fun IntentScreen(navController: NavHostController) {
     EventEffect(
         event = viewState.showIntent,
         onConsumed = vm::intentShown,
-    ) { intentLauncher.launch(it) }
+    ) {
+        try {
+            intentLauncher.launch(it)
+        } catch (e: ActivityNotFoundException) {
+            vm.intentResultReceived(null)
+        }
+    }
 
     val menuExpanded = remember { mutableStateOf(false) }
     val scrollState = rememberScrollState()

--- a/app/src/main/java/com/simprints/intentlauncher/ui/intent/IntentViewModel.kt
+++ b/app/src/main/java/com/simprints/intentlauncher/ui/intent/IntentViewModel.kt
@@ -9,6 +9,8 @@ import com.simprints.intentlauncher.data.store.ProjectDataCache
 import com.simprints.intentlauncher.domain.IntentCall
 import com.simprints.intentlauncher.domain.IntentCallRepository
 import com.simprints.intentlauncher.domain.IntentFields
+import com.simprints.intentlauncher.domain.IntentResult
+import com.simprints.intentlauncher.domain.IntentResult.Companion.SID_NOT_INSTALLED
 import com.simprints.intentlauncher.domain.IntentResultParser
 import com.simprints.intentlauncher.tools.extractEventsFromJson
 import com.simprints.libsimprints.Metadata
@@ -132,8 +134,12 @@ class IntentViewModel @Inject constructor(
         showIntent = triggered(request),
     )
 
-    fun intentResultReceived(result: SimprintsResponse) = viewModelScope.launch {
-        val intentResult = intentResultParser(result)
+    fun intentResultReceived(result: SimprintsResponse?) = viewModelScope.launch {
+        val intentResult = if (result == null) {
+            IntentResult(code = SID_NOT_INSTALLED)
+        } else {
+            intentResultParser(result)
+        }
         val lastIntentCall = viewState.value.lastIntentCall
 
         lastIntentCall?.let {


### PR DESCRIPTION
* For regular intents, if Simprints ID isn't installed, notifying in the result section accordingly.
* For custom intents, notifying if the specifying action was not resolved. _Note: this can be the case if Simprints ID is installed but the action isn't anything that Simprints ID supports._

<img src="https://github.com/user-attachments/assets/b47d3b95-a260-4d8e-b984-e3e59cef6a3a" width="400">
<img src="https://github.com/user-attachments/assets/e73d3e0e-fdbe-4502-9ad4-f4fb426b3538" width="399">


